### PR TITLE
Working density reinitialisation

### DIFF
--- a/Test_Settings.txt
+++ b/Test_Settings.txt
@@ -1,13 +1,12 @@
-VERSION: SPHView00
-
 SIMULATION PARAMETERS:
-	Number of frames (5)
+	Number of frames (2000)
 	Steps per frame (10)
-	Time step (0.0001)
-	Number of particles (16900)
-	Particle size (0.005)
+	Time step (0.0002)
+	Particle Spacing (0.1)
+	Particle Mass (10)
 	Reference density (1000)
-	Bulk modulus (4.2039e-45)
-	Dynamic viscosity (0.1)
-	Gravitational strength (9.81)
-
+	Support Radius (0.0977205)
+	Gravitational strength (-9.81)
+	Number of boundary points (716)
+	Number of simulation points (950)
+	Integrator type (Newmark_Beta)

--- a/WCSPH.cpp
+++ b/WCSPH.cpp
@@ -348,7 +348,7 @@ void write_frame_data(State particles, std::ofstream& fp)
         fp << b->rho << " "  << b->p << std::endl;
   	}
 
-    fp <<  "ZONE t=\"Particle Data\", STRANDID=2, SOLUTIONTIME=" << t << std::endl;
+    fp <<  "ZONE t=\"Particle Data\", STRANDID=1, SOLUTIONTIME=" << t << ", DATAPACKING=POINT" << std::endl;
   	for (auto p=std::next(particles.begin(),bound_parts); p!=particles.end(); ++p)
 	{
 		//Eigen::Vector2d a=  p->f/p->rho;

--- a/WCSPH.cpp
+++ b/WCSPH.cpp
@@ -24,6 +24,7 @@
 #include <KDTreeVectorOfVectorsAdaptor.h>
 #include <cstdlib>
 
+
 #ifndef M_PI
 #define M_PI (4.0*atan(1.0))
 #endif
@@ -55,7 +56,7 @@ const static double B = rho0*pow(Cs,2)/gam; /*Factor for Tait's Eq*/
 
 // SPH Parameters
 const static double H = sqrt((3/M_PI)*(mass/rho0)); /*Support Radius*/
-const static double HSQ = H*H; 
+const static double HSQ = H*H;
 const static double r0 = Pstep;		/*Boundary support radius*/
 const static double D = pow(Cs,2);	/*Boundary param 1*/
 const static float N1 = 4;			/*Boundary param 2*/
@@ -94,21 +95,21 @@ double Kernel(double dist)
 	double q = dist/H;
 	if (q<3)
 		return exp(-q*q)/(M_PI*HSQ);
-	else 
+	else
 		return 0;
 }
 
 /*Smoothing Kernel Gradient*/
-Vector2d GradK(Vector2d Rij, double dist) 
+Vector2d GradK(Vector2d Rij, double dist)
 {
 	double q = dist/H;
 	if (q<3)
 		return 2*(Rij/HSQ)*exp(-q*q)/(M_PI*HSQ);
-	else 
+	else
 		return Vector2d(0,0);
 }
 
-double W2Kernel(double dist) 
+double W2Kernel(double dist)
 {
 	double q = dist/H;
 	if (q < 2)
@@ -126,12 +127,12 @@ Vector2d W2GradK(Vector2d Rij, double dist)
 		return Vector2d(0.0,0.0);
 }
 
-void Forces(State &part,my_kd_tree_t &mat_index) 
+void Forces(State &part,my_kd_tree_t &mat_index)
 {
 	double alpha = 0.025;
-	for (auto &pi :part) 
+	for (auto &pi :part)
 	{
-		
+
 		//Reset the particle to zero
 		pi.f = zero;
 		pi.fp = zero;
@@ -142,14 +143,14 @@ void Forces(State &part,my_kd_tree_t &mat_index)
 		pi.Rrho=0.0;
 		std::vector<std::pair<size_t,double>> matches;
 		mat_index.index->radiusSearch(&pi.xi[0], search_radius, matches, params);
-		for (auto &i: matches) 
+		for (auto &i: matches)
 		{
 			Particle pj = part[i.first];
 			Vector2d Rij = pj.xi-pi.xi;
 			Vector2d Vij = pj.v-pi.v;
 			double r = Rij.norm();
 			Vector2d Grad = W2GradK(Rij, r);
-			
+
 			// if (pj.b==false) {
 			/*Pressure and artificial viscosity calc - Monaghan 1994 p.400*/
 				double cbar= 0.5*(sqrt((B*gam)/pi.rho)+sqrt((B*gam)/pj.rho));
@@ -161,37 +162,37 @@ void Forces(State &part,my_kd_tree_t &mat_index)
 				if (vdotr > 0) pifac = 0;
 
 				contrib += Grad*(pifac + pi.p/pow(pi.rho,2)+ pj.p/pow(pj.rho,2));
-			
+
 			//}
 
-			// if (pj.b == true && r < r0) 
+			// if (pj.b == true && r < r0)
 			// {
 			// 	contrib -= D*(pow((r0/r),N1)-pow((r0/r),N2))*Rij/Rij.squaredNorm();
 			// 	pi.fb+=contrib*mass;
 			// }
 
-			
+
 			Rrhocontr += (Vij.dot(Grad));
-			
-			
+
+
 		}
 		pi.Rrho = Rrhocontr*mass;
 		pi.f= contrib*mass;
 		pi.f(1) += -9.81; /*Add gravity*/
 		pi.fp = contrib*mass;
-		
+
 		//cout << pi.f << endl;
 	}
 
 }
 
-void PredictorCorrector(State &p, State &ph, my_kd_tree_t &mat_index) 
+void PredictorCorrector(State &p, State &ph, my_kd_tree_t &mat_index)
 {
-	
+
 	/*Predict*/
 	Forces(p, mat_index); /*Find forces at time n*/
-	
-	// for (auto i=0; i< p.size(); ++i) 
+
+	// for (auto i=0; i< p.size(); ++i)
 	// 	cout << p[i].f(0) << "\t" << p[i].f(1) << endl;
 
 	/*Set boundary forces to zero to stop movement of the boundary*/
@@ -199,7 +200,7 @@ void PredictorCorrector(State &p, State &ph, my_kd_tree_t &mat_index)
 		p[i].f = zero;
 
 	for (size_t i=0; i < p.size() ; ++i )
-	{		
+	{
 		ph[i].v = p[i].v+0.5*dt*p[i].f;
 		ph[i].rho = p[i].rho+0.5*dt*p[i].Rrho;
 		ph[i].xi = p[i].xi+0.5*dt*p[i].v;
@@ -229,7 +230,7 @@ void PredictorCorrector(State &p, State &ph, my_kd_tree_t &mat_index)
 	t+=dt;
 }
 
-void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index) 
+void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index)
 {
 	for (int k = 0; k < subits; ++k)
 	{
@@ -256,21 +257,21 @@ void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index)
 	t+=dt;
 
 }
-void InitSPH(State &particles) 
+void InitSPH(State &particles)
 {
 	cout << "Initialising simulation with " << SimPts << " particles" << endl;
-	
+
 	//Structure input initialiser
 	//Particle(Vector2d x, Vector2d v, Vector2d vh, Vector2d f, float rho, float Rrho, bool bound) :
-	 
-	Vector2d v(0.0,0.0);  
-	Vector2d f(0.0,0.0); 
-	float rho=rho0; 
-	float Rrho=0.0; 
+
+	Vector2d v(0.0,0.0);
+	Vector2d f(0.0,0.0);
+	float rho=rho0;
+	float Rrho=0.0;
 
 
-	/*create the boundary particles*/ 
-	 
+	/*create the boundary particles*/
+
 	static double stepx = r0*0.7;
 	static double stepy = r0*0.7;
 	const static int Ny = ceil(BoxH/stepy);
@@ -293,20 +294,20 @@ void InitSPH(State &particles)
 		Vector2d xi(i*stepx,0.f);
 		particles.push_back(Particle(xi,v,f,rho,Rrho,true));
 	}
-	
+
 	bound_parts = particles.size();
-	
+
 
 	/*Create the simulation particles*/
-	for( int i=0; i< xyPART(0); ++i) 
+	for( int i=0; i< xyPART(0); ++i)
 	{
 		for(int j=0; j< xyPART(1); ++j)
-		{				
-				Vector2d xi(Start(0)+i*Pstep,Start(1)+j*Pstep);		
+		{
+				Vector2d xi(Start(0)+i*Pstep,Start(1)+j*Pstep);
 				particles.push_back(Particle(xi,v,f,rho,Rrho,false));
 		}
 	}
-
+	cout << "Total Particles: " << SimPts + bound_parts << endl;
 }
 void write_settings()
 {
@@ -322,23 +323,10 @@ void write_settings()
     fp << "\tParticle Mass ("<< mass << ")" << std::endl;
     fp << "\tReference density ("<< rho0 << ")" << std::endl;
     fp << "\tSupport Radius ("<< H << ")" << std::endl;
-    //fp << "\tGas Constant ("<< GAS_CONST << ")" << std::endl;
-    //fp << "\tDynamic viscosity ("<< VISC << ")" << std::endl;
-    fp << "\tGravitational strength ("<< -9.81 << ")" << std::endl;
+    fp << "\tGravitational strength ("<< 9.81 << ")" << std::endl;
     fp << "\tNumber of boundary points (" << bound_parts << ")" << std::endl;
     fp << "\tNumber of simulation points (" << SimPts << ")" << std::endl;
-    fp << "\tIntegrator type (Newmark_Beta)" << std::endl; ;
-    	// switch (integrator) {
-    	// 	case 'E':
-	    // 		fp << "Euler Explicit)" << std::endl;
-	    // 		break;
-    	// 	case 'L': 
-    	// 		fp << "Leapfrog)" << std::endl;
-    	// 		break;
-    	// 	case 'N':
-    	// 		fp <<"Newmark_Beta)" << std::endl;
-    	// 		break;
-    	// }
+    fp << "\tIntegrator type (Newmark_Beta)" << std::endl;
 
     fp.close();
   }
@@ -348,7 +336,7 @@ void write_settings()
   }
 }
 
-void write_frame_data(State particles, std::ofstream& fp, std::ofstream& f2)
+void write_frame_data(State particles, std::ofstream& fp)
 {
     fp <<  "ZONE t=\"Boundary Data\", STRANDID=1, SOLUTIONTIME=" << t << std::endl;
   	for (auto b=particles.begin(); b!=std::next(particles.begin(),bound_parts); ++b)
@@ -370,31 +358,22 @@ void write_frame_data(State particles, std::ofstream& fp, std::ofstream& f2)
 			cerr << p->xi(0) << " " << p->xi(1) << " ";
 	        cerr << p->v(0) << " " << p->v(1) << " ";
 	        cerr << p->f(0) << " " << p->f(1) << " ";
-	        cerr << p->rho << " " << p->p << std::endl; 
+	        cerr << p->rho << " " << p->p << std::endl;
 	        fp.close();
 			exit(-1);
 		}
         fp << p->xi(0) << " " << p->xi(1) << " ";
         fp << p->v(0) << " " << p->v(1) << " ";
         fp << p->f(0) << " " << p->f(1) << " ";
-        fp << p->rho << " "  << p->p << std::endl; 
+        fp << p->rho << " "  << p->p << std::endl;
   	}
-
-	f2 << "Fpx, Fpy, Fvx, Fvy, Fgx, Fgy, Fbx, Fby " << endl;
-    for (auto p=std::next(particles.begin(),bound_parts); p!=particles.end(); ++p)
-	{
-		f2 << p->fp(0) << " " << p->fp(1) << " ";
-		f2 << p->fv(0) << " " << p->fv(1) << " ";
-		f2 << 0.0 << " " << -9.81 << " ";
-		f2 << p->fb(0) << " " << p->fb(1) << endl;
-	}
 
 }
 
-int main(int argc, char *argv[]) 
+int main(int argc, char *argv[])
 {
 	high_resolution_clock::time_point t1 = high_resolution_clock::now();
-	
+
 	//initialise the vector<Particle> particles
 	State particles;
 	State particlesh;
@@ -403,7 +382,7 @@ int main(int argc, char *argv[])
 	InitSPH(particles);
 	for (auto p: particles)
 			particlesh.push_back(Particle(p.xi,p.v,p.f,p.rho,p.Rrho,p.b));
-	
+
 	my_kd_tree_t mat_index(2,particlesh,10);
 	mat_index.index->buildIndex();
 
@@ -414,28 +393,27 @@ int main(int argc, char *argv[])
 	/*Write settings*/
 	write_settings();
 
-	/*Open simulation files*/
+	/*Open simulation file*/
 	std::ofstream f1("Test.plt", std::ios::out);
-	std::ofstream f2("Forces.txt", std::ios::out);
 
 	if (f1.is_open())
 	{
 		f1 << std::fixed << setprecision(3);
-		f2 << std::fixed << setprecision(3);
+
 		cout << "Starting simulation..." << endl;
 		//Write file header defining veriable names
 		f1 <<  "VARIABLES = x, y, Vx, Vy, fx, fy, rho, P" << std::endl;
-		write_frame_data(particles, f1, f2);
+		write_frame_data(particles, f1);
 
 		for (int frame = 1; frame<= Nframe; ++frame) {
 				  cout << "Frame Number: " << frame << endl;
 				  for (int i=0; i< Ndtframe; ++i) {
 				    Newmark_Beta(particles, particlesh, mat_index);
 				  }
-				   write_frame_data(particles, f1, f2);
+				   write_frame_data(particles, f1);
 				}
 	f1.close();
-	f2.close();
+
 	}
 	else
 	{

--- a/WCSPH_XSPH.cpp
+++ b/WCSPH_XSPH.cpp
@@ -22,6 +22,7 @@
 #include <dirent.h>
 #include <chrono>
 #include <Eigen/Dense>
+#include <Eigen/StdVector>
 #include <nanoflann.hpp>
 #include <utils.h>
 #include <KDTreeVectorOfVectorsAdaptor.h>
@@ -57,7 +58,7 @@ const static double B = rho0*pow(Cs,2)/gam; /*Factor for Tait's Eq*/
 
 // SPH Parameters
 const static double H = sqrt((3/M_PI)*(mass/rho0)); /*Support Radius*/
-const static double HSQ = H*H;
+const static double HSQ = H*H; 
 const static double r0 = Pstep;		/*Boundary support radius*/
 const static double D = pow(Cs,2);	/*Boundary param 1*/
 const static float N1 = 4;			/*Boundary param 2*/
@@ -78,6 +79,7 @@ const static Vector2d zero(0.0,0.0);
 typedef struct Particle {
 Particle(Vector2d x, Vector2d v, Vector2d f, float rho, float Rrho, bool bound)	:
 	xi(x), v(v), V(0.0,0.0),  f(f), rho(rho), p(0.0), Rrho(Rrho), b(bound){}
+	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 	Vector2d xi, v, V, f;
 	float rho, p, Rrho;
 	bool b;
@@ -93,28 +95,27 @@ typedef KDTreeVectorOfVectorsAdaptor<State, double> my_kd_tree_t;
 const static double search_radius = 4*HSQ+0.001*H;
 nanoflann::SearchParams params;
 
-/*Gaussian Smoothing Kernel*/
+/*Smoothing Kernel*/
 double Kernel(double dist)
 {
 	double q = dist/H;
 	if (q<3)
 		return exp(-q*q)/(M_PI*HSQ);
-	else
+	else 
 		return 0;
 }
 
-/*Gaussian Kernel Gradient*/
-Vector2d GradK(Vector2d Rij, double dist)
+/*Smoothing Kernel Gradient*/
+Vector2d GradK(Vector2d Rij, double dist) 
 {
 	double q = dist/H;
 	if (q<3)
 		return 2*(Rij/HSQ)*exp(-q*q)/(M_PI*HSQ);
-	else
+	else 
 		return Vector2d(0,0);
 }
 
-//Wendland's C2 Kernel
-double W2Kernel(double dist)
+double W2Kernel(double dist) 
 {
 	double q = dist/H;
 	if (q < 2)
@@ -132,25 +133,25 @@ Vector2d W2GradK(Vector2d Rij, double dist)
 		return Vector2d(0.0,0.0);
 }
 
-void Forces(State &part,my_kd_tree_t &mat_index)
+void Forces(State &part,my_kd_tree_t &mat_index) 
 {
 	maxmu=0; /* CFL Parameter */
 	double alpha = 0.025; /* Artificial Viscosity Parameter*/
 	double eps = 0.1; /* XSPH Influence Parameter*/
-	for (auto &pi :part)
+	for (auto &pi :part) 
 	{
-
+		
 		//Reset the particle to zero
 		pi.f = zero;
 		pi.V = pi.v;
 		Vector2d contrib(0.0,0.0);
 		double Rrhocontr = 0.0;
 		pi.Rrho=0.0;
-
+		
 		vector<double> mu;
 		std::vector<std::pair<size_t,double>> matches; /* Nearest Neighbour Search*/
 		mat_index.index->radiusSearch(&pi.xi[0], search_radius, matches, params);
-		for (auto &i: matches)
+		for (auto &i: matches) 
 		{
 			Particle pj = part[i.first];
 			if(&pi == &pj)
@@ -161,7 +162,7 @@ void Forces(State &part,my_kd_tree_t &mat_index)
 			double r = Rij.norm();
 			double Kern = W2Kernel(r);
 			Vector2d Grad = W2GradK(Rij, r);
-
+			
 			// if (pj.b==false) {
 			/*Pressure and artificial viscosity calc - Monaghan 1994 p.400*/
 				double cbar= 0.5*(sqrt((B*gam)/pi.rho)+sqrt((B*gam)/pj.rho));
@@ -173,23 +174,23 @@ void Forces(State &part,my_kd_tree_t &mat_index)
 
 				if (vdotr > 0) pifac = 0;
 				contrib += Grad*(pifac + pi.p/pow(pi.rho,2)+ pj.p/pow(pj.rho,2));
-
+			
 			//}
 
-			// if (pj.b == true && r < r0)
+			// if (pj.b == true && r < r0) 
 			// {
 			// 	contrib -= D*(pow((r0/r),N1)-pow((r0/r),N2))*Rij/Rij.squaredNorm();
 			// }
 			//if (pj.b==false)
 				pi.V+=eps*(mass/rhoij)*Kern*Vij; /* XSPH Influence*/
 			Rrhocontr += (Vij.dot(Grad));
-
-
+			
+			
 		}
 		pi.Rrho = Rrhocontr*mass; /*drho/dt*/
 		pi.f= contrib*mass;
 		pi.f(1) += -9.81; /*Add gravity*/
-
+		
 		//CFL f_cv Calc
 		double it = *max_element(mu.begin(),mu.end());
 		if (it > maxmu)
@@ -210,52 +211,47 @@ void DensityReinit(State &p, my_kd_tree_t &mat_index)
 		//Find matrix A.
 		std::vector<std::pair<size_t,double>> matches;
 		mat_index.index->radiusSearch(&pi.xi[0], search_radius, matches, params);
-		for (auto &i: matches)
+		for (auto &i: matches) 
 		{
 			Particle pj = p[i.first];
 			if(&pi == &pj)
 				continue;
 
-			Vector2d Rij = pi.xi - pj.xi;
-			Matrix3d Abar ;
-			Abar << 1      , Rij(0)        ,  Rij(1)       ,
-						  Rij(0) , pow(Rij(0),2) ,  Rij(1)*Rij(0),
-							Rij(1) , Rij(1)*Rij(0) ,  pow(Rij(1),2);
+			Matrix3d Abar ;	
+			Abar << 1, pi.xi(0)-pj.xi(0), pi.xi(1)-pj.xi(1),
+				pi.xi(0)-pj.xi(0), pow(pi.xi(0)-pj.xi(0),2),(pi.xi(1)-pj.xi(1))*(pi.xi(0)-pj.xi(0)),
+				pi.xi(1)-pj.xi(1),(pi.xi(1)-pj.xi(1))*(pi.xi(0)-pj.xi(0)),pow(pi.xi(1)-pj.xi(1),2);
 
-			A+=Abar*W2Kernel(Rij.norm());
+			A+=(mass/pj.rho)*Abar*W2Kernel((pi.xi-pj.xi).norm());
+
 		}
-
-		// Reinitialise density
 		Vector3d Beta = A.inverse()*one;
-		pi.rho=0.0;
-		double rho = 0.0;
-		cout << Beta(0) << " " << Beta(1) << " " << Beta(2) << endl;
+		pi.rho=0;
 		for (auto &i: matches)
 		{
 			Particle pj= p[i.first];
 			if(&pi == &pj)
 				continue;
-
 			Vector2d Rij = pi.xi-pj.xi;
-			rho += W2Kernel(Rij.norm())*(Beta(0)+Beta(1)*Rij(0)+Beta(2)*Rij(1));
+			double dist = Rij.norm();
+			pi.rho += W2Kernel(dist)*(Beta(0)+Beta(1)*Rij(0)+Beta(2)*Rij(1));
 		}
-
-		pi.rho =rho*mass;
+		pi.rho *= mass;
 	}
-
+	
 }
 
-void PredictorCorrector(State &p, State &ph, my_kd_tree_t &mat_index)
+void PredictorCorrector(State &p, State &ph, my_kd_tree_t &mat_index) 
 {
 	/*Predict*/
 	Forces(p, mat_index); /*Find forces at time n*/
-
+	
 	/*Set boundary forces to zero to stop movement of the boundary*/
 	for (size_t i=0; i < bound_parts; ++i)
 		p[i].f = zero;
 
 	for (size_t i=0; i < p.size() ; ++i )
-	{
+	{		
 		ph[i].v = p[i].v+0.5*dt*p[i].f;
 		ph[i].rho = p[i].rho+0.5*dt*p[i].Rrho;
 		ph[i].xi = p[i].xi+0.5*dt*p[i].V;
@@ -285,10 +281,10 @@ void PredictorCorrector(State &p, State &ph, my_kd_tree_t &mat_index)
 	t+=dt;
 }
 
-void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index)
+void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index) 
 {
 	for (int k = 0; k < subits; ++k)
-	{
+	{	
 		Forces(pnp1, mat_index); /*Guess force at time n+1*/
 		for (size_t i=0; i < bound_parts; ++i)
 		{
@@ -309,7 +305,7 @@ void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index)
 			pnp1[i].p = B*(pow(pnp1[i].rho/rho0,gam)-1);
 		}
 		mat_index.index->buildIndex();
-
+		
 		errsum = 0.0;
 		for (size_t i=0; i < pnp1.size(); ++i)
 		{
@@ -317,7 +313,7 @@ void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index)
 			errsum += r.squaredNorm();
 		}
 	}
-
+	
 	vector<Particle>::iterator maxfi = std::max_element(pnp1.begin(),pnp1.end(),
 		[](Particle p1, Particle p2){return p1.f.norm()< p2.f.norm();});
 	maxf = maxfi->f.norm();
@@ -330,58 +326,58 @@ void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index)
 	t+=dt;
 
 }
-void InitSPH(State &particles)
+void InitSPH(State &particles) 
 {
 	cout << "Initialising simulation with " << SimPts << " particles" << endl;
-
+	
 	//Structure input initialiser
 	//Particle(Vector2d x, Vector2d v, Vector2d vh, Vector2d f, float rho, float Rrho, bool bound) :
+	 
+	Vector2d v(0.0,0.0);  
+	Vector2d f(0.0,0.0); 
+	float rho=rho0; 
+	float Rrho=0.0; 
 
-	Vector2d v(0.0,0.0);
-	Vector2d f(0.0,0.0);
-	float rho=rho0;
-	float Rrho=0.0;
 
-
-	/*Create the boundary particles*/
-
+	/*create the boundary particles*/ 
+	 
 	static double stepx = r0*0.7;
 	static double stepy = r0*0.7;
 	const static int Ny = ceil(Box(1)/stepy);
 	stepy = Box(1)/Ny;
 	const static int Nx = ceil(Box(0)/stepx);
 	stepx = Box(0)/Nx;
-
+	
 	for(int i = 0; i <= Ny ; ++i) {
 		Vector2d xi(0.f,i*stepy);
-		particles.push_back(Particle(xi,v,f,rho,Rrho,true));
+		particles.emplace_back(Particle(xi,v,f,rho,Rrho,true));
 	}
 	for(int i = 1; i <Nx ; ++i) {
 		Vector2d xi(i*stepx,Box(1));
-		particles.push_back(Particle(xi,v,f,rho,Rrho,true));
+		particles.emplace_back(Particle(xi,v,f,rho,Rrho,true));
 	}
 	for(int i= Ny; i>0; --i) {
 		Vector2d xi(Box(0),i*stepy);
-		particles.push_back(Particle(xi,v,f,rho,Rrho,true));
+		particles.emplace_back(Particle(xi,v,f,rho,Rrho,true));
 	}
 	for(int i = Nx; i > 0; --i) {
 		Vector2d xi(i*stepx,0.f);
-		particles.push_back(Particle(xi,v,f,rho,Rrho,true));
+		particles.emplace_back(Particle(xi,v,f,rho,Rrho,true));
 	}
-
+	
 	bound_parts = particles.size();
-
+	
 
 	/*Create the simulation particles*/
-	for( int i=0; i< xyPART(0); ++i)
+	for( int i=0; i< xyPART(0); ++i) 
 	{
 		for(int j=0; j< xyPART(1); ++j)
-		{
-				Vector2d xi(Start(0)+i*Pstep,Start(1)+j*Pstep);
-				particles.push_back(Particle(xi,v,f,rho,Rrho,false));
+		{				
+				Vector2d xi(Start(0)+i*Pstep,Start(1)+j*Pstep);		
+				particles.emplace_back(Particle(xi,v,f,rho,Rrho,false));
 		}
 	}
-	cout << "Total Particles: " << SimPts + bound_parts << endl;
+
 }
 void write_settings()
 {
@@ -407,7 +403,7 @@ void write_settings()
     	// 	case 'E':
 	    // 		fp << "Euler Explicit)" << std::endl;
 	    // 		break;
-    	// 	case 'L':
+    	// 	case 'L': 
     	// 		fp << "Leapfrog)" << std::endl;
     	// 		break;
     	// 	case 'N':
@@ -445,23 +441,23 @@ void write_frame_data(State particles, std::ofstream& fp)
 			cerr << p->xi(0) << " " << p->xi(1) << " ";
 	        cerr << p->v(0) << " " << p->v(1) << " ";
 	        cerr << p->f(0) << " " << p->f(1) << " ";
-	        cerr << p->rho << " " << p->p << std::endl;
+	        cerr << p->rho << " " << p->p << std::endl; 
 	        fp.close();
 			exit(-1);
 		}
         fp << p->xi(0) << " " << p->xi(1) << " ";
         fp << p->v.norm() << " ";
         fp << p->f.norm() << " ";
-        fp << p->rho << " "  << p->p << std::endl;
+        fp << p->rho << " "  << p->p << std::endl; 
   	}
 
 
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char *argv[]) 
 {
 	high_resolution_clock::time_point t1 = high_resolution_clock::now();
-
+	
 	//initialise the vector<Particle> particles
 	State particles;
 	State particlesh;
@@ -469,8 +465,8 @@ int main(int argc, char *argv[])
 	/*Initialise particles*/
 	InitSPH(particles);
 	for (auto p: particles)
-			particlesh.push_back(Particle(p.xi,p.v,p.f,p.rho,p.Rrho,p.b));
-
+			particlesh.emplace_back(Particle(p.xi,p.v,p.f,p.rho,p.Rrho,p.b));
+	
 	my_kd_tree_t mat_index(2,particlesh,10);
 	mat_index.index->buildIndex();
 
@@ -483,11 +479,11 @@ int main(int argc, char *argv[])
 
 	/*Open simulation files*/
 	std::ofstream f1("Test.plt", std::ios::out);
-
+	
 	if (f1.is_open())
 	{
 		f1 << std::fixed << setprecision(3);
-
+		
 		cout << "Starting simulation..." << endl;
 		//Write file header defining veriable names
 		f1 <<  "VARIABLES = x, y, V, F, rho, P" << std::endl;
@@ -502,7 +498,7 @@ int main(int argc, char *argv[])
 				  write_frame_data(particles, f1);
 				}
 	f1.close();
-
+	
 	}
 	else
 	{

--- a/WCSPH_XSPH.cpp
+++ b/WCSPH_XSPH.cpp
@@ -216,26 +216,28 @@ void DensityReinit(State &p, my_kd_tree_t &mat_index)
 			if(&pi == &pj)
 				continue;
 
+			Vector2d Rij = pi.xi - pj.xi;
 			Matrix3d Abar ;
-			Abar << 1, pi.xi(0)-pj.xi(0), pi.xi(1)-pj.xi(1),
-				pi.xi(0)-pj.xi(0), pow(pi.xi(0)-pj.xi(0),2),(pi.xi(1)-pj.xi(1))*(pi.xi(0)-pj.xi(0)),
-				pi.xi(1)-pj.xi(1),(pi.xi(1)-pj.xi(1))*(pi.xi(0)-pj.xi(0)),pow(pi.xi(1)-pj.xi(1),2);
+			Abar << 1      , Rij(0)        ,  Rij(1)       ,
+						  Rij(0) , pow(Rij(0),2) ,  Rij(1)*Rij(0),
+							Rij(1) , Rij(1)*Rij(0) ,  pow(Rij(1),2);
 
-			A+=(mass/pj.rho)*Abar*W2Kernel((pi.xi-pj.xi).norm());
+			A+=Abar*W2Kernel(Rij.norm());
 		}
 
 		// Reinitialise density
 		Vector3d Beta = A.inverse()*one;
 		pi.rho=0.0;
 		double rho = 0.0;
+		cout << Beta(0) << " " << Beta(1) << " " << Beta(2) << endl;
 		for (auto &i: matches)
 		{
 			Particle pj= p[i.first];
 			if(&pi == &pj)
 				continue;
+
 			Vector2d Rij = pi.xi-pj.xi;
-			double dist = Rij.norm();
-			rho += W2Kernel(dist)*(Beta(0)+Beta(1)*Rij(0)+Beta(2)*Rij(1));
+			rho += W2Kernel(Rij.norm())*(Beta(0)+Beta(1)*Rij(0)+Beta(2)*Rij(1));
 		}
 
 		pi.rho =rho*mass;

--- a/WCXSPH.cpp
+++ b/WCXSPH.cpp
@@ -1,6 +1,8 @@
 /*** WCSPH (Weakly Compressible Smoothed Particle Hydrodynamics) Code***/
 /********* Created by Jamie MacLeod, University of Bristol *************/
 /*** Force Calculation: On Simulating Free Surface Flows using SPH. Monaghan, J.J. (1994) ***/
+/***			+ XSPH Correction (Also described in Monaghan) ***/
+/*** Density Reinitialisation as in Colagrossi, A. and Landrini, M. (2003): Moving Least Squares***/
 /*** Smoothing Kernel: Wendland's C2 ***/
 /*** Integrator: Newmark-Beta ****/
 /*** Variable Timestep Criteria: CFL + Monaghan, J.J. (1989) conditions ***/
@@ -10,14 +12,8 @@
 #include <cmath>
 #include <vector>
 #include <fstream>
-#include <float.h>
 #include <string.h>
 #include <sstream>
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <unistd.h>
-#include <dirent.h>
 #include <chrono>
 #include <Eigen/Dense>
 #include <Eigen/StdVector>
@@ -25,8 +21,6 @@
 #include <nanoflann.hpp>
 #include <utils.h>
 #include <KDTreeVectorOfVectorsAdaptor.h>
-#include <cstdlib>
-
 
 #ifndef M_PI
 #define M_PI (4.0*atan(1.0))
@@ -39,49 +33,52 @@ using namespace nanoflann;
 
 /*Make these from input file at some point...*/
 //Simulation Definition
-const static Vector2i xyPART(25,38); /*Number of particles in (x,y) directions*/
+const static Vector2i xyPART(25,35); /*Number of particles in (x,y) directions*/
 const static unsigned int SimPts = xyPART(0)*xyPART(1); /*total sim particles*/
 static size_t bound_parts;			/*Number of boundary particles*/
+static int npts;
 const static double Pstep = 0.1;	/*Initial particle spacing*/
 
 //Simulation window parameters
-const static Vector2d Box(15.0, 8.0);   /*Boundary dimensions*/
-const static Vector2d Start(0.31,0.31); /*Simulation particles start + end coords*/
+const static Vector2d Box(15,5); /*Boundary dimensions*/
+const static Vector2d Start(0.15,0.11); /*Simulation particles start + end coords*/
 const static Vector2d Finish(Start(0)+Pstep*xyPART(0)*1.0,Start(1)+Pstep*xyPART(1)*1.0);
 
 //Fluid Properties
 const static double rho0 = 1000.0; /*Rest density*/
-const static double mass = rho0*((Finish(0)-Start(0))*(Finish(1)-Start(1))/(1.0*SimPts));
+const static double Simmass = rho0*((Finish(0)-Start(0))*(Finish(1)-Start(1))/(1.0*SimPts));
+const static double Boundmass = 0.9*rho0*((Finish(0)-Start(0))*(Finish(1)-Start(1))/(1.0*SimPts));
 const static double Cs = 50; /*Speed of sound*/
 const static double gam = 7.0; /*Factor for Tait's Eq*/
 const static double B = rho0*pow(Cs,2)/gam; /*Factor for Tait's Eq*/
 
 // SPH Parameters
-const static double H = sqrt((3/M_PI)*(mass/rho0)); /*Support Radius*/
-const static double HSQ = H*H;
+const static double H = sqrt((3/M_PI)*(Simmass/rho0)); /*Support Radius*/
+const static double HSQ = H*H; 
 const static double r0 = Pstep;		/*Boundary support radius*/
 const static double D = pow(Cs,2);	/*Boundary param 1*/
 const static float N1 = 4;			/*Boundary param 2*/
 const static float N2 = 2;			/*Boundary param 3*/
+
+//Timestep Parameters
 static double dt = 0.0002;	/*Timestep*/
-static float t = 0.0;				/*Current time in sim*/
+static float t = 0.f;				/*Current time in sim*/
 const static float beta = 0.25;		/*Newmark-Beta parameter*/
 const static int subits = 8;		/*Newmark-Beta iterations*/
 const static int Nframe = 2000;		/*Number of output frames*/
 const static int Ndtframe = 10; 	/*Timesteps per frame*/
-
-static double maxmu = 0;	/*CFL Max steps*/
-static double maxf = 0;		/*CFL */
+static double maxmu = 0;
+static double maxf = 0;
 static double errsum = 0.0;
+static double logbase = 0.0;
 const static Vector2d zero(0.0,0.0);
 
-
 typedef struct Particle {
-Particle(Vector2d x, Vector2d v, Vector2d f, float rho, float Rrho, bool bound)	:
-	xi(x), v(v),  f(f), rho(rho), p(0.0), Rrho(Rrho), b(bound) {}
+Particle(Vector2d x, Vector2d v, Vector2d f, float rho, float Rrho, float m,bool bound)	:
+	xi(x), v(v), V(0.0,0.0),  f(f), rho(rho), p(0.0), Rrho(Rrho), m(m), b(bound){}
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-	Vector2d xi, v, f;
-	float rho, p, Rrho;
+	Vector2d xi, v, V, f;
+	float rho, p, Rrho, m;
 	bool b;
 	int size() const {return(xi.size());}
 	double operator[](int a) const {
@@ -89,9 +86,10 @@ Particle(Vector2d x, Vector2d v, Vector2d f, float rho, float Rrho, bool bound)	
 	}
 }Particle;
 
+
 typedef std::vector<Particle> State;
 typedef KDTreeVectorOfVectorsAdaptor<State, double> my_kd_tree_t;
-const static double search_radius = 4*HSQ+0.001*H;
+const static double search_radius = 4*HSQ;
 nanoflann::SearchParams params;
 
 /*Smoothing Kernel*/
@@ -100,21 +98,21 @@ double Kernel(double dist)
 	double q = dist/H;
 	if (q<3)
 		return exp(-q*q)/(M_PI*HSQ);
-	else
+	else 
 		return 0;
 }
 
 /*Smoothing Kernel Gradient*/
-Vector2d GradK(Vector2d Rij, double dist)
+Vector2d GradK(Vector2d Rij, double dist) 
 {
 	double q = dist/H;
 	if (q<3)
 		return 2*(Rij/HSQ)*exp(-q*q)/(M_PI*HSQ);
-	else
+	else 
 		return Vector2d(0,0);
 }
 
-double W2Kernel(double dist)
+double W2Kernel(double dist) 
 {
 	double q = dist/H;
 	if (q < 2)
@@ -132,58 +130,62 @@ Vector2d W2GradK(Vector2d Rij, double dist)
 		return Vector2d(0.0,0.0);
 }
 
-void Forces(State &part,my_kd_tree_t &mat_index)
+void Forces(State &part,my_kd_tree_t &mat_index) 
 {
-	maxmu=0; /* CFL Parameter */
-	double alpha = 0.025;
-	for (auto &pi :part)
+	maxmu=0; 				/* CFL Parameter */
+	double alpha = 0.025; 	/* Artificial Viscosity Parameter*/
+	double eps = 0.2; 		/* XSPH Influence Parameter*/
+	for (auto &pi :part) 
 	{
-
+		
 		//Reset the particle to zero
 		pi.f = zero;
-		
+		pi.V = pi.v;
 		Vector2d contrib(0.0,0.0);
 		double Rrhocontr = 0.0;
 		pi.Rrho=0.0;
-
+		
 		vector<double> mu;
-		std::vector<std::pair<size_t,double>> matches;
+		std::vector<std::pair<size_t,double>> matches; /* Nearest Neighbour Search*/
 		mat_index.index->radiusSearch(&pi.xi[0], search_radius, matches, params);
-		for (auto &i: matches)
+		for (auto &i: matches) 
 		{
 			Particle pj = part[i.first];
+			// if(&pi == &pj)
+			// 	continue;
+
 			Vector2d Rij = pj.xi-pi.xi;
 			Vector2d Vij = pj.v-pi.v;
 			double r = Rij.norm();
+			double Kern = W2Kernel(r);
 			Vector2d Grad = W2GradK(Rij, r);
-
+			
 			// if (pj.b==false) {
 			/*Pressure and artificial viscosity calc - Monaghan 1994 p.400*/
 				double cbar= 0.5*(sqrt((B*gam)/pi.rho)+sqrt((B*gam)/pj.rho));
-				double vdotr = Vij(0)*Rij(0)+Vij(1)*Rij(1);
+				double vdotr = Vij.dot(Rij);
 				double rhoij = 0.5*(pi.rho+pj.rho);
 				double muij= H*vdotr/(r*r+0.01*HSQ);
 				mu.emplace_back(muij);
 				double pifac = alpha*cbar*muij/rhoij;
 
 				if (vdotr > 0) pifac = 0;
-
-				contrib += Grad*(pifac + pi.p/pow(pi.rho,2)+ pj.p/pow(pj.rho,2));
-
+				contrib += pj.m*Grad*(pifac + pi.p/pow(pi.rho,2)+ pj.p/pow(pj.rho,2));
+			
 			//}
 
-			// if (pj.b == true && r < r0)
+			// if (pj.b == true && r < r0) 
 			// {
 			// 	contrib -= D*(pow((r0/r),N1)-pow((r0/r),N2))*Rij/Rij.squaredNorm();
 			// }
-
-
-			Rrhocontr += (Vij.dot(Grad));
-
-
+			//if (pj.b==false)
+			pi.V+=eps*(pj.m/rhoij)*Kern*Vij; /* XSPH Influence*/
+			Rrhocontr += pj.m*(Vij.dot(Grad));
+			
+			
 		}
-		pi.Rrho = Rrhocontr*mass;
-		pi.f= contrib*mass;
+		pi.Rrho = Rrhocontr; /*drho/dt*/
+		pi.f= contrib;
 		pi.f(1) += -9.81; /*Add gravity*/
 		
 		//CFL f_cv Calc
@@ -215,7 +217,7 @@ void DensityReinit(State &p, my_kd_tree_t &mat_index)
 				    Rij(0) , Rij(0)*Rij(0) , Rij(1)*Rij(0) ,
 				    Rij(1) , Rij(1)*Rij(0) , Rij(1)*Rij(1) ;
 
-			A+= W2Kernel(Rij.norm())*Abar*mass/pj.rho;
+			A+= W2Kernel(Rij.norm())*Abar*pj.m/pj.rho;
 		}
 		
 		//Check if A is invertible
@@ -231,7 +233,7 @@ void DensityReinit(State &p, my_kd_tree_t &mat_index)
 		for (auto &i: matches)
 		{
 			Vector2d Rij = pi.xi-p[i.first].xi;
-			rho += mass*W2Kernel(Rij.norm())*(Beta(0)+Beta(1)*Rij(0)+Beta(2)*Rij(1));
+			rho += p[i.first].m*W2Kernel(Rij.norm())*(Beta(0)+Beta(1)*Rij(0)+Beta(2)*Rij(1));
 		}
 
 		pi.rho = rho;
@@ -239,21 +241,20 @@ void DensityReinit(State &p, my_kd_tree_t &mat_index)
 	
 }
 
-void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index)
+void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index) 
 {
 	vector<Vector2d> xih;
 	for (auto pi :pnp1)
 		xih.emplace_back(pi.xi);
 
 	for (int k = 0; k < subits; ++k)
-	{
+	{	
 		Forces(pnp1, mat_index); /*Guess force at time n+1*/
 		for (size_t i=0; i < bound_parts; ++i)
 		{
 			pnp1[i].f = zero; /*Zero boundary forces*/
 			pn[i].f = zero;   /*So that they dont move*/
 		}
-
 		/*Previous State for error calc*/
 		for (size_t  i=0; i< xih.size(); ++i)
 			xih[i] = pnp1[i].xi;
@@ -263,46 +264,52 @@ void Newmark_Beta(State &pn, State &pnp1, my_kd_tree_t &mat_index)
 		{
 			pnp1[i].v = pn[i].v+0.5*dt*(pn[i].f+pnp1[i].f);
 			pnp1[i].rho = pn[i].rho+0.5*dt*(pn[i].Rrho+pnp1[i].Rrho);
-			pnp1[i].xi = pn[i].xi+dt*pn[i].v+0.5*(dt*dt)*(1-2*beta)*pn[i].f+(dt*dt*beta)*pnp1[i].f;
+			pnp1[i].xi = pn[i].xi+dt*pn[i].V+0.5*(dt*dt)*(1-2*beta)*pn[i].f+(dt*dt*beta)*pnp1[i].f;
 			pnp1[i].p = B*(pow(pnp1[i].rho/rho0,gam)-1);
 		}
 		mat_index.index->buildIndex();
+		
+		errsum = 0.0;
+		for (size_t i=0; i < pnp1.size(); ++i)
+		{
+			Vector2d r = pnp1[i].xi-xih[i];
+			errsum += r.squaredNorm();
+		}
+
+		if(k == 0)
+			logbase=log10(sqrt(errsum/(1.0*npts)));
+	}
+
 	
-	}
-
-	errsum = 0.0;
-	for (size_t i=0; i < pnp1.size(); ++i)
-	{
-		Vector2d r = pnp1[i].xi-xih[i];
-		errsum += r.squaredNorm();
-	}
-
+	/*Find maximum safe timestep*/
 	vector<Particle>::iterator maxfi = std::max_element(pnp1.begin(),pnp1.end(),
 		[](Particle p1, Particle p2){return p1.f.norm()< p2.f.norm();});
 	maxf = maxfi->f.norm();
 	double dtf = sqrt(H/maxf);
 	double dtcv = H/(Cs+maxmu);
 	dt = 0.3*min(dtf,dtcv);
+
 	//Update the state at time n
 	pn = pnp1;
 	t+=dt;
-
 }
-void InitSPH(State &particles)
+
+
+void InitSPH(State &particles) 
 {
 	cout << "Initialising simulation with " << SimPts << " particles" << endl;
-
+	
 	//Structure input initialiser
 	//Particle(Vector2d x, Vector2d v, Vector2d vh, Vector2d f, float rho, float Rrho, bool bound) :
+	 
+	Vector2d v(0.0,0.0);  
+	Vector2d f(0.0,0.0); 
+	float rho=rho0; 
+	float Rrho=0.0; 
 
-	Vector2d v(0.0,0.0);
-	Vector2d f(0.0,0.0);
-	float rho=rho0;
-	float Rrho=0.0;
 
-
-	/*create the boundary particles*/
-
+	/*create the boundary particles*/ 
+	 
 	static double stepx = r0*0.7;
 	static double stepy = r0*0.7;
 	const static int Ny = ceil(Box(1)/stepy);
@@ -312,19 +319,19 @@ void InitSPH(State &particles)
 	
 	for(int i = 0; i <= Ny ; ++i) {
 		Vector2d xi(0.f,i*stepy);
-		particles.emplace_back(Particle(xi,v,f,rho,Rrho,true));
+		particles.emplace_back(Particle(xi,v,f,rho,Rrho,Boundmass,true));
 	}
 	for(int i = 1; i <Nx ; ++i) {
 		Vector2d xi(i*stepx,Box(1));
-		particles.emplace_back(Particle(xi,v,f,rho,Rrho,true));
+		particles.emplace_back(Particle(xi,v,f,rho,Rrho,Boundmass,true));
 	}
 	for(int i= Ny; i>0; --i) {
 		Vector2d xi(Box(0),i*stepy);
-		particles.emplace_back(Particle(xi,v,f,rho,Rrho,true));
+		particles.emplace_back(Particle(xi,v,f,rho,Rrho,Boundmass,true));
 	}
 	for(int i = Nx; i > 0; --i) {
 		Vector2d xi(i*stepx,0.f);
-		particles.emplace_back(Particle(xi,v,f,rho,Rrho,true));
+		particles.emplace_back(Particle(xi,v,f,rho,Rrho,Boundmass,true));
 	}
 	
 	bound_parts = particles.size();
@@ -336,7 +343,7 @@ void InitSPH(State &particles)
 		for(int j=0; j< xyPART(1); ++j)
 		{				
 				Vector2d xi(Start(0)+i*Pstep,Start(1)+j*Pstep);		
-				particles.emplace_back(Particle(xi,v,f,rho,Rrho,false));
+				particles.emplace_back(Particle(xi,v,f,rho,Rrho,Simmass,false));
 		}
 	}
 
@@ -345,28 +352,28 @@ void InitSPH(State &particles)
 void write_settings()
 {
 	std::ofstream fp("Test_Settings.txt", std::ios::out);
-  
-	if(fp.is_open()) {
-		//fp << "VERSION: " << VERSION_TAG << std::endl << std::endl; //Write version
-		fp << "SIMULATION PARAMETERS:" << std::endl; //State the system parameters.
-		fp << "\tNumber of frames (" << Nframe <<")" << std::endl;
-		fp << "\tSteps per frame ("<< Ndtframe << ")" << std::endl;
-		fp << "\tTime step (" << dt << ")" << std::endl;
-		fp << "\tParticle Spacing ("<< Pstep << ")" << std::endl;
-		fp << "\tParticle Mass ("<< mass << ")" << std::endl;
-		fp << "\tReference density ("<< rho0 << ")" << std::endl;
-		fp << "\tSupport Radius ("<< H << ")" << std::endl;
-		fp << "\tGravitational strength ("<< 9.81 << ")" << std::endl;
-		fp << "\tNumber of boundary points (" << bound_parts << ")" << std::endl;
-		fp << "\tNumber of simulation points (" << SimPts << ")" << std::endl;
-		fp << "\tIntegrator type (Newmark_Beta)" << std::endl;
 
-		fp.close();
-	}
-	else {
-		cout << "Error opening the output file." << endl;
-		exit(-1);
-	}
+  if(fp.is_open()) {
+    //fp << "VERSION: " << VERSION_TAG << std::endl << std::endl; //Write version
+    fp << "SIMULATION PARAMETERS:" << std::endl; //State the system parameters.
+    fp << "\tNumber of frames (" << Nframe <<")" << std::endl;
+    fp << "\tSteps per frame ("<< Ndtframe << ")" << std::endl;
+    fp << "\tTime step (" << dt << ")" << std::endl;
+    fp << "\tParticle Spacing ("<< Pstep << ")" << std::endl;
+    fp << "\tParticle Mass ("<< Simmass << ")" << std::endl;
+    fp << "\tReference density ("<< rho0 << ")" << std::endl;
+    fp << "\tSupport Radius ("<< H << ")" << std::endl;
+    fp << "\tGravitational strength ("<< 9.81 << ")" << std::endl;
+    fp << "\tNumber of boundary points (" << bound_parts << ")" << std::endl;
+    fp << "\tNumber of simulation points (" << SimPts << ")" << std::endl;
+    fp << "\tIntegrator type (Newmark_Beta)" << std::endl;
+
+    fp.close();
+  }
+  else {
+    cout << "Error opening the output file." << endl;
+    exit(-1);
+  }
 }
 
 void write_frame_data(State particles, std::ofstream& fp)
@@ -374,14 +381,13 @@ void write_frame_data(State particles, std::ofstream& fp)
     fp <<  "ZONE t=\"Boundary Data\", STRANDID=1, SOLUTIONTIME=" << t << std::endl;
   	for (auto b=particles.begin(); b!=std::next(particles.begin(),bound_parts); ++b)
 	{
-		//Vector2d a=  p.f/p.rho;
         fp << b->xi(0) << " " << b->xi(1) << " ";
         fp << b->v.norm() << " ";
         fp << b->f.norm() << " ";
         fp << b->rho << " "  << b->p << std::endl;
   	}
 
-    fp <<  "ZONE t=\"Particle Data\", STRANDID=2, SOLUTIONTIME=" << t << ", DATAPACKING=POINT" << std::endl;
+    fp <<  "ZONE t=\"Particle Data\", STRANDID=2, SOLUTIONTIME=" << t << std::endl;
   	for (auto p=std::next(particles.begin(),bound_parts); p!=particles.end(); ++p)
 	{
 		//Eigen::Vector2d a=  p->f/p->rho;
@@ -389,33 +395,35 @@ void write_frame_data(State particles, std::ofstream& fp)
 			cerr << endl << "Simulation is broken. A value is nan." << endl;
 			cerr << "Broken line..." << endl;
 			cerr << p->xi(0) << " " << p->xi(1) << " ";
-	        cerr << p->v(0) << " " << p->v(1) << " ";
-	        cerr << p->f(0) << " " << p->f(1) << " ";
-	        cerr << p->rho << " " << p->p << std::endl;
+	        cerr << p->v.norm() << " ";
+	        cerr << p->f.norm() << " ";
+	        cerr << p->rho << " " << p->p << std::endl; 
 	        fp.close();
 			exit(-1);
 		}
         fp << p->xi(0) << " " << p->xi(1) << " ";
         fp << p->v.norm() << " ";
         fp << p->f.norm() << " ";
-        fp << p->rho << " "  << p->p << std::endl;
+        fp << p->rho << " "  << p->p << std::endl; 
   	}
+
 
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char *argv[]) 
 {
 	high_resolution_clock::time_point t1 = high_resolution_clock::now();
-
+	
 	//initialise the vector<Particle> particles
 	State particles;
 	State particlesh;
 
 	/*Initialise particles*/
 	InitSPH(particles);
+	npts = bound_parts + SimPts;
 	for (auto p: particles)
-			particlesh.emplace_back(Particle(p.xi,p.v,p.f,p.rho,p.Rrho,p.b));
-
+			particlesh.emplace_back(p);
+	
 	my_kd_tree_t mat_index(2,particlesh,10);
 	mat_index.index->buildIndex();
 
@@ -426,21 +434,20 @@ int main(int argc, char *argv[])
 	/*Write settings*/
 	write_settings();
 
-	/*Open simulation file*/
+	/*Open simulation files*/
 	std::ofstream f1("Test.plt", std::ios::out);
-
+	
 	if (f1.is_open())
 	{
 		f1 << std::fixed << setprecision(3);
-
+		
 		cout << "Starting simulation..." << endl;
 		//Write file header defining veriable names
 		f1 <<  "VARIABLES = x, y, V, F, rho, P" << std::endl;
 		write_frame_data(particles, f1);
-		const static int npts = bound_parts + SimPts;
 		
 		for (int frame = 1; frame<= Nframe; ++frame) {
-				  cout << "Frame Number: " << frame << "\tError: " << log10(sqrt(errsum/(1.0*npts))) << endl;
+				  cout << "Frame Number: " << frame << "\tError: " << log10(sqrt(errsum/(1.0*npts)))-logbase << endl;
 				  for (int i=0; i< Ndtframe; ++i) {
 				    Newmark_Beta(particles, particlesh, mat_index);
 				  }
@@ -448,7 +455,7 @@ int main(int argc, char *argv[])
 				  write_frame_data(particlesh, f1);
 				}
 	f1.close();
-
+	
 	}
 	else
 	{

--- a/makefile
+++ b/makefile
@@ -2,8 +2,8 @@ CXX=g++
 LIBS = -I /usr/local/include/eigen3 -I /usr/local/include
 CFLAGS=-g -fbounds-check -std=c++11 -O3 -fstrict-aliasing 
 
-WCSPH : WCSPH.cpp
-	$(CXX) $(LIBS) $(CFLAGS) $@ -o  $<
+WCSPH : WCSPH_XSPH.cpp
+	$(CXX) $(LIBS) $(CFLAGS) -o $@ $<
 
 linux: WCSPH
 	./WCSPH Sample_Input.txt

--- a/makefile
+++ b/makefile
@@ -1,10 +1,11 @@
 CXX=g++
+LIBS = -I /usr/local/include/eigen3 -I /usr/local/include
 CFLAGS=-g -fbounds-check -std=c++11 -O3 -fstrict-aliasing 
 
-WCSPH : WCSPH_XSPH.cpp
-	$(CXX) $(CFLAGS) -o  $@ $<
+WCSPH : WCSPH.cpp
+	$(CXX) $(LIBS) $(CFLAGS) $@ -o  $<
 
-lin: WCSPH
+linux: WCSPH
 	./WCSPH Sample_Input.txt
 
 win: WCSPH

--- a/makefile
+++ b/makefile
@@ -1,13 +1,16 @@
 CXX=g++
 INC= -I C:\cygwin64\usr\include\eigen3 -I C:\cygwin64\usr\local\include 
 CFLAGS= -g -fbounds-check -std=c++11 -O3 -fstrict-aliasing -o
+exe = WCSPH
 
-WCSPH : WCSPH_XSPH.cpp
-	$(CXX) $(INC) $(CFLAGS) $@ $< 
+SPH : WCSPH.cpp
+	$(CXX) $(INC) $(CFLAGS) $(exe) $< 
+
+XSPH : WCXSPH.cpp
+	$(CXX) $(INC) $(CFLAGS) $(exe) $< 
 
 linux: WCSPH
 	./WCSPH Sample_Input.txt
 
 win: WCSPH
 	./WCSPH.exe Sample_Input.txt
-

--- a/makefile
+++ b/makefile
@@ -1,12 +1,13 @@
 CXX=g++
-LIBS = -I /usr/local/include/eigen3 -I /usr/local/include
-CFLAGS=-g -fbounds-check -std=c++11 -O3 -fstrict-aliasing 
+INC= -I C:\cygwin64\usr\include\eigen3 -I C:\cygwin64\usr\local\include 
+CFLAGS= -g -fbounds-check -std=c++11 -O3 -fstrict-aliasing -o
 
 WCSPH : WCSPH_XSPH.cpp
-	$(CXX) $(LIBS) $(CFLAGS) -o $@ $<
+	$(CXX) $(INC) $(CFLAGS) $@ $< 
 
 linux: WCSPH
 	./WCSPH Sample_Input.txt
 
 win: WCSPH
 	./WCSPH.exe Sample_Input.txt
+


### PR DESCRIPTION
The density reinitialisation has been incorporated and is working, and the codes have been made near-enough identical (error is slightly different) aside from the XSPH correction. This has let me prove that the XSPH correction is much better when there are few neighbours to smooth the density values. When particles are isolated and next to the boundary, they tend to stick without the XSPH correction. 
Still to do:
Add viscosity and surface tension. 
Benchmark?
settings input file?