### PR TITLE
Extended the XSPH code to 3D

### DIFF
--- a/WCSPH.cpp
+++ b/WCSPH.cpp
@@ -149,6 +149,7 @@ void Forces(State &part,my_kd_tree_t &mat_index)
 		pi.Rrho=0.0;
 
 		vector<double> mu;
+		mu.emplace_back(0);
 		std::vector<std::pair<size_t,double>> matches;
 		mat_index.index->radiusSearch(&pi.xi[0], search_radius, matches, params);
 		for (auto &i: matches)

--- a/makefile
+++ b/makefile
@@ -9,6 +9,9 @@ SPH : WCSPH.cpp
 XSPH : WCXSPH.cpp
 	$(CXX) $(INC) $(CFLAGS) $(exe) $< 
 
+3D	: WCXSPH3D.cpp
+	$(CXX) $(INC) $(CFLAGS) $(exe) $< 
+
 linux: WCSPH
 	./WCSPH Sample_Input.txt
 


### PR DESCRIPTION
This actually also caught a bug waiting to happen. I'm surprised it hadn't been caused before, but if the particle were to have no neighbours then a vector, mu, would have no members to perform a std::max_element check on. This caused a SEGV in the 3D code, and I've remedied it across the other codes.